### PR TITLE
fix(ci): remove NOCTUA_TOKEN that was removed

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -16,4 +16,4 @@ jobs:
     # secrets: inherit
     secrets:
       CHARMHUB_TOKEN: ${{ secrets.CHARMHUB_TOKEN }}
-      OBSERVABILITY_NOCTUA_TOKEN: "unused"
+


### PR DESCRIPTION
The API of the workflow got modified in: https://github.com/canonical/observability/commit/924ff36dead22099976a156750e47c07b6bf5134