### PR TITLE
fix(charmcraft): set 3.1.10 as the minimum juju version since it's th…

### DIFF
--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -5,7 +5,7 @@ description: |
 type: charm
 assumes:
   - k8s-api
-  - juju >= 3.4.3
+  - juju >= 3.1.10
 bases:
   - build-on:
     - name: ubuntu


### PR DESCRIPTION
Set `3.1.10` since it is the minimum Juju version of the multipass vm: https://github.com/canonical/multipass-blueprints/blob/ae90147b811a79eaf4508f4776390141e0195fe7/v1/charm-dev.yaml#L52


This way we can upgrade safely 