### PR TITLE
include external host in csrf trusted origins to use with TLS

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -423,6 +423,7 @@ class CosRegistrationServerCharm(CharmBase):
                             "ALLOWED_HOST_DJANGO": f"{self.external_host},{self.internal_host}",
                             "SCRIPT_NAME": f"/{self.model.name}-{self.model.app.name}",
                             "COS_MODEL_NAME": f"{self.model.name}",
+                            "CSRF_TRUSTED_ORIGINS": f"https://{self.external_host}",
                         },
                     }
                 },

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -74,6 +74,7 @@ class TestCharm(unittest.TestCase):
                             "ALLOWED_HOST_DJANGO": f"{self.external_host},{self.harness.charm.internal_host}",
                             "SCRIPT_NAME": f"/{self.harness._backend.model_name}-{self.harness._backend.app_name}",
                             "COS_MODEL_NAME": f"{self.harness._backend.model_name}",
+                            "CSRF_TRUSTED_ORIGINS": f"https://{self.external_host}",
                         },
                     }
                 },


### PR DESCRIPTION
Add environment variable for CSRF trusted origins to Pebble layer for Django service.

this ensures Django admin POST requests work correctly over HTTPS.

The variable in django database is introduced in https://github.com/canonical/cos-registration-server/pull/66