### PR TITLE
Tests/migration to jubilant

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,5 +32,3 @@ extraPaths = ["lib"]
 pythonVersion = "3.8"
 pythonPlatform = "All"
 
-[tool.pytest.ini_options]
-asyncio_mode = "auto"

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -3,7 +3,7 @@ import os
 import pathlib
 import subprocess
 from collections.abc import Generator
-from typing import Any, Dict, cast
+from typing import Any, Dict
 
 import jubilant
 import pytest

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -20,6 +20,7 @@ from tests.integration.constants import (
     APP_TRACING,
     BLACKBOX_APP,
     BLACKBOX_PROBES,
+    COS_CHANNEL,
     GRAFANA_AGENT_APP,
     GRAFANA_AGENT_GRAFANA_DASHBOARD,
     GRAFANA_AGENT_LOGGING_PROVIDER,
@@ -134,13 +135,13 @@ def app_fixture(
         trust=True,
     )
 
-    juju.deploy(PROMETHEUS_APP, channel="1/stable", trust=True)
+    juju.deploy(PROMETHEUS_APP, channel=COS_CHANNEL, trust=True)
 
-    juju.deploy(GRAFANA_AGENT_APP, channel="1/stable")
+    juju.deploy(GRAFANA_AGENT_APP, channel=COS_CHANNEL)
 
-    juju.deploy(BLACKBOX_APP, channel="1/stable", trust=True)
+    juju.deploy(BLACKBOX_APP, channel=COS_CHANNEL, trust=True)
 
-    juju.deploy(SSC_APP, channel="1/stable", trust=True)
+    juju.deploy(SSC_APP, channel=COS_CHANNEL, trust=True)
 
     logger.info(
         "Adding relation: %s:%s and %s:%s",

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -233,26 +233,15 @@ def app_fixture(
     juju.integrate(f"{app_name}:{APP_CERTIFICATES}", f"{SSC_APP}:{SSC_CERTIFICATES}")
 
     juju.wait(
-        lambda status: jubilant.all_active(status, PROMETHEUS_APP),
-        timeout=1000,
-    )
-    juju.wait(
-        lambda status: jubilant.all_active(status, POSTGRESQL_APP),
-        timeout=1000,
-    )
-    juju.wait(
-        lambda status: jubilant.all_active(status, BLACKBOX_APP),
+        lambda status: jubilant.all_active(
+            status, PROMETHEUS_APP, POSTGRESQL_APP, BLACKBOX_PROBES, SSC_APP, app_name
+        ),
         timeout=1000,
     )
 
-    juju.wait(
-        lambda status: jubilant.all_active(status, SSC_APP),
-        timeout=1000,
-    )
-
-    juju.wait(lambda status: jubilant.all_active(status, app_name), timeout=1000)
-    # we do not wait for grafana_agent_app since it's
+    # grafana_agent_app is
     # in a blocked state by design.
+    juju.wait(lambda status: jubilant.all_blocked(status, GRAFANA_AGENT_APP), timeout=1000)
 
     return app_name
 

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -236,12 +236,12 @@ def app_fixture(
         lambda status: jubilant.all_active(
             status, PROMETHEUS_APP, POSTGRESQL_APP, BLACKBOX_PROBES, SSC_APP, app_name
         ),
-        timeout=1000,
+        timeout=5000,
     )
 
     # grafana_agent_app is
     # in a blocked state by design.
-    juju.wait(lambda status: jubilant.all_blocked(status, GRAFANA_AGENT_APP), timeout=1000)
+    juju.wait(lambda status: jubilant.all_blocked(status, GRAFANA_AGENT_APP), timeout=5000)
 
     return app_name
 

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -149,7 +149,10 @@ def app_fixture(
         POSTGRESQL_APP,
         POSTGRESQL_DATABASE,
     )
-    juju.integrate(app_name, f"{POSTGRESQL_APP}:{POSTGRESQL_DATABASE}")
+    juju.integrate(
+        f"{app_name}:{APP_DATABASE}",
+        f"{POSTGRESQL_APP}:{POSTGRESQL_DATABASE}",
+    )
 
     logger.info(
         "Adding relation: %s:%s and %s:%s",

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -1,4 +1,5 @@
 import logging
+import os
 import pathlib
 import subprocess
 from collections.abc import Generator
@@ -42,15 +43,6 @@ from tests.integration.constants import (
 logger = logging.getLogger(__name__)
 
 
-def pytest_addoption(parser: pytest.Parser) -> None:
-    parser.addoption(
-        "--charm-file",
-        action="store",
-        default=None,
-        help="Use an existing built charm instead of packing",
-    )
-
-
 def alert_rule_files() -> None:
     """Create alert rule files & directory if it does not exist."""
     LOKI_ALERT_RULE_FILES_DIRECTORY_DEVICES.mkdir(parents=True, exist_ok=True)
@@ -74,6 +66,13 @@ def pytest_sessionstart(session):
     grafana_dashboards_files()
 
 
+def _env_flag(name: str, default: bool = False) -> bool:
+    value = os.environ.get(name)
+    if value is None:
+        return default
+    return value.strip().lower() in {"1", "true", "yes", "on"}
+
+
 @pytest.fixture(scope="module")
 def juju(request: pytest.FixtureRequest) -> Generator[jubilant.Juju, None, None]:
     """Pytest fixture that wraps :meth:`jubilant.with_model`."""
@@ -83,21 +82,21 @@ def juju(request: pytest.FixtureRequest) -> Generator[jubilant.Juju, None, None]
             log = juju.debug_log(limit=1000)
             print(log, end="")
 
-    use_existing = request.config.getoption("--use-existing", default=False)
+    use_existing = _env_flag("JUJU_USE_EXISTING", default=False)
     if use_existing:
         juju = jubilant.Juju()
         yield juju
         show_debug_log(juju)
         return
 
-    model = request.config.getoption("--model")
+    model = os.environ.get("JUJU_MODEL")
     if model:
         juju = jubilant.Juju(model=model)
         yield juju
         show_debug_log(juju)
         return
 
-    keep_models = cast(bool, request.config.getoption("--keep-models"))
+    keep_models = _env_flag("JUJU_KEEP_MODELS", default=False)
     with jubilant.temp_model(keep=keep_models) as juju:
         juju.wait_timeout = 10 * 60
         yield juju
@@ -255,9 +254,9 @@ def app_fixture(
 
 
 @pytest.fixture(scope="session")
-def charm_file(metadata: Dict[str, Any], pytestconfig: pytest.Config):
+def charm_file(metadata: Dict[str, Any]):
     """Pytest fixture that packs the charm and returns the filename, or --charm-file if set."""
-    charm_file = pytestconfig.getoption("--charm-file")
+    charm_file = os.environ.get("CHARM_FILE")
     if charm_file:
         return charm_file
 

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -236,7 +236,7 @@ def app_fixture(
         lambda status: jubilant.all_active(
             status, PROMETHEUS_APP, POSTGRESQL_APP, BLACKBOX_APP, SSC_APP, app_name
         ),
-        timeout=15*60,
+        timeout=15 * 60,
     )
 
     # grafana_agent_app is

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -234,7 +234,7 @@ def app_fixture(
 
     juju.wait(
         lambda status: jubilant.all_active(
-            status, PROMETHEUS_APP, POSTGRESQL_APP, BLACKBOX_PROBES, SSC_APP, app_name
+            status, PROMETHEUS_APP, POSTGRESQL_APP, BLACKBOX_APP, SSC_APP, app_name
         ),
         timeout=5000,
     )

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -1,0 +1,274 @@
+import logging
+import pathlib
+import subprocess
+from collections.abc import Generator
+from typing import Any, Dict, cast
+
+import jubilant
+import pytest
+import yaml
+
+from tests.integration.constants import (
+    APP_CERTIFICATES,
+    APP_DATABASE,
+    APP_GRAFANA_DASHBOARD_DEVICES,
+    APP_LOKI_ALERT_RULE_FILES_DEVICES,
+    APP_PROBES,
+    APP_PROBES_DEVICES,
+    APP_PROMETHEUS_ALERT_RULE_FILES_DEVICES,
+    APP_TRACING,
+    BLACKBOX_APP,
+    BLACKBOX_PROBES,
+    GRAFANA_AGENT_APP,
+    GRAFANA_AGENT_GRAFANA_DASHBOARD,
+    GRAFANA_AGENT_LOGGING_PROVIDER,
+    GRAFANA_AGENT_TRACING_ENDPOINT,
+    GRAFANA_DASHBOARD_FILE,
+    GRAFANA_DASHBOARD_FILES_DIRECTORY_DEVICES,
+    LOKI_ALERT_RULE_FILE,
+    LOKI_ALERT_RULE_FILES_DIRECTORY_DEVICES,
+    POSTGRESQL_APP,
+    POSTGRESQL_APP_CHANNEL,
+    POSTGRESQL_DATABASE,
+    PROMETHEUS_ALERT_RULE_FILE,
+    PROMETHEUS_ALERT_RULE_FILES_DIRECTORY_DEVICES,
+    PROMETHEUS_APP,
+    PROMETHEUS_RECEIVE_REMOTE_WRITE,
+    RESOURCE_NAME,
+    SSC_APP,
+    SSC_CERTIFICATES,
+)
+
+logger = logging.getLogger(__name__)
+
+
+def pytest_addoption(parser: pytest.Parser) -> None:
+    parser.addoption(
+        "--charm-file",
+        action="store",
+        default=None,
+        help="Use an existing built charm instead of packing",
+    )
+
+
+def alert_rule_files() -> None:
+    """Create alert rule files & directory if it does not exist."""
+    LOKI_ALERT_RULE_FILES_DIRECTORY_DEVICES.mkdir(parents=True, exist_ok=True)
+    PROMETHEUS_ALERT_RULE_FILES_DIRECTORY_DEVICES.mkdir(parents=True, exist_ok=True)
+    (LOKI_ALERT_RULE_FILES_DIRECTORY_DEVICES / "my_rule.rule").write_text(LOKI_ALERT_RULE_FILE)
+    (PROMETHEUS_ALERT_RULE_FILES_DIRECTORY_DEVICES / "my_rule.rule").write_text(
+        PROMETHEUS_ALERT_RULE_FILE
+    )
+
+
+def grafana_dashboards_files() -> None:
+    """Create Grafana dashboard files & directory if it does not exist."""
+    GRAFANA_DASHBOARD_FILES_DIRECTORY_DEVICES.mkdir(parents=True, exist_ok=True)
+    (GRAFANA_DASHBOARD_FILES_DIRECTORY_DEVICES / "my-dashboard.json").write_text(
+        GRAFANA_DASHBOARD_FILE
+    )
+
+
+def pytest_sessionstart(session):
+    alert_rule_files()
+    grafana_dashboards_files()
+
+
+@pytest.fixture(scope="module")
+def juju(request: pytest.FixtureRequest) -> Generator[jubilant.Juju, None, None]:
+    """Pytest fixture that wraps :meth:`jubilant.with_model`."""
+
+    def show_debug_log(juju: jubilant.Juju):
+        if request.session.testsfailed:
+            log = juju.debug_log(limit=1000)
+            print(log, end="")
+
+    use_existing = request.config.getoption("--use-existing", default=False)
+    if use_existing:
+        juju = jubilant.Juju()
+        yield juju
+        show_debug_log(juju)
+        return
+
+    model = request.config.getoption("--model")
+    if model:
+        juju = jubilant.Juju(model=model)
+        yield juju
+        show_debug_log(juju)
+        return
+
+    keep_models = cast(bool, request.config.getoption("--keep-models"))
+    with jubilant.temp_model(keep=keep_models) as juju:
+        juju.wait_timeout = 10 * 60
+        yield juju
+        show_debug_log(juju)
+        return
+
+
+@pytest.fixture(scope="session")
+def metadata() -> Dict[str, Any]:
+    """Provides charm metadata."""
+    return yaml.safe_load(pathlib.Path("./charmcraft.yaml").read_text(encoding="UTF-8"))
+
+
+@pytest.fixture(scope="module", name="cos_registration_server")
+def app_fixture(
+    juju: jubilant.Juju,
+    metadata: Dict[str, Any],
+    charm_file: str,
+):
+    """Builds and deploys the charm and its required relations/resources."""
+    app_name = metadata["name"]
+
+    charm_oci_image = metadata["resources"][RESOURCE_NAME]["upstream-source"]
+    charm_resources = {RESOURCE_NAME: charm_oci_image}
+
+    juju.deploy(
+        charm=charm_file,
+        app=app_name,
+        resources=charm_resources,
+    )
+
+    juju.deploy(
+        POSTGRESQL_APP,
+        channel=POSTGRESQL_APP_CHANNEL,
+        trust=True,
+    )
+
+    juju.deploy(PROMETHEUS_APP, channel="1/stable", trust=True)
+
+    juju.deploy(GRAFANA_AGENT_APP, channel="1/stable")
+
+    juju.deploy(BLACKBOX_APP, channel="1/stable", trust=True)
+
+    juju.deploy(SSC_APP, channel="1/stable", trust=True)
+
+    logger.info(
+        "Adding relation: %s:%s and %s:%s",
+        app_name,
+        APP_DATABASE,
+        POSTGRESQL_APP,
+        POSTGRESQL_DATABASE,
+    )
+    juju.integrate(app_name, f"{POSTGRESQL_APP}:{POSTGRESQL_DATABASE}")
+
+    logger.info(
+        "Adding relation: %s:%s and %s:%s",
+        app_name,
+        APP_GRAFANA_DASHBOARD_DEVICES,
+        GRAFANA_AGENT_APP,
+        GRAFANA_AGENT_GRAFANA_DASHBOARD,
+    )
+    juju.integrate(
+        f"{app_name}:{APP_GRAFANA_DASHBOARD_DEVICES}",
+        f"{GRAFANA_AGENT_APP}:{GRAFANA_AGENT_GRAFANA_DASHBOARD}",
+    )
+
+    logger.info(
+        "Adding relation: %s:%s and %s:%s",
+        app_name,
+        APP_LOKI_ALERT_RULE_FILES_DEVICES,
+        GRAFANA_AGENT_APP,
+        GRAFANA_AGENT_LOGGING_PROVIDER,
+    )
+    juju.integrate(
+        f"{app_name}:{APP_LOKI_ALERT_RULE_FILES_DEVICES}",
+        f"{GRAFANA_AGENT_APP}:{GRAFANA_AGENT_LOGGING_PROVIDER}",
+    )
+
+    logger.info(
+        "Adding relation: %s:%s and %s:%s",
+        app_name,
+        APP_PROMETHEUS_ALERT_RULE_FILES_DEVICES,
+        PROMETHEUS_APP,
+        PROMETHEUS_RECEIVE_REMOTE_WRITE,
+    )
+    # We cannot use the grafana agent since it doesn't have a
+    # receive-remote-write integration
+    juju.integrate(
+        f"{app_name}:{APP_PROMETHEUS_ALERT_RULE_FILES_DEVICES}",
+        f"{PROMETHEUS_APP}:{PROMETHEUS_RECEIVE_REMOTE_WRITE}",
+    )
+
+    logger.info(
+        "Adding relation: %s:%s and %s:%s",
+        app_name,
+        APP_TRACING,
+        GRAFANA_AGENT_APP,
+        GRAFANA_AGENT_TRACING_ENDPOINT,
+    )
+    juju.integrate(
+        f"{app_name}:{APP_TRACING}",
+        f"{GRAFANA_AGENT_APP}:{GRAFANA_AGENT_TRACING_ENDPOINT}",
+    )
+
+    logger.info(
+        "Adding relation: %s:%s and %s:%s",
+        app_name,
+        APP_PROBES,
+        BLACKBOX_APP,
+        BLACKBOX_PROBES,
+    )
+    juju.integrate(f"{app_name}:{APP_PROBES}", f"{BLACKBOX_APP}:{BLACKBOX_PROBES}")
+
+    logger.info(
+        "Adding relation: %s:%s and %s:%s",
+        app_name,
+        APP_PROBES_DEVICES,
+        BLACKBOX_APP,
+        BLACKBOX_PROBES,
+    )
+    juju.integrate(f"{app_name}:{APP_PROBES_DEVICES}", f"{BLACKBOX_APP}:{BLACKBOX_PROBES}")
+
+    logger.info(
+        "Adding relation: %s:%s and %s:%s",
+        app_name,
+        APP_CERTIFICATES,
+        SSC_APP,
+        SSC_CERTIFICATES,
+    )
+    juju.integrate(f"{app_name}:{APP_CERTIFICATES}", f"{SSC_APP}:{SSC_CERTIFICATES}")
+
+    juju.wait(
+        lambda status: jubilant.all_active(status, PROMETHEUS_APP),
+        timeout=1000,
+    )
+    juju.wait(
+        lambda status: jubilant.all_active(status, POSTGRESQL_APP),
+        timeout=1000,
+    )
+    juju.wait(
+        lambda status: jubilant.all_active(status, BLACKBOX_APP),
+        timeout=1000,
+    )
+
+    juju.wait(
+        lambda status: jubilant.all_active(status, SSC_APP),
+        timeout=1000,
+    )
+
+    juju.wait(lambda status: jubilant.all_active(status, app_name), timeout=1000)
+    # we do not wait for grafana_agent_app since it's
+    # in a blocked state by design.
+
+    return app_name
+
+
+@pytest.fixture(scope="session")
+def charm_file(metadata: Dict[str, Any], pytestconfig: pytest.Config):
+    """Pytest fixture that packs the charm and returns the filename, or --charm-file if set."""
+    charm_file = pytestconfig.getoption("--charm-file")
+    if charm_file:
+        return charm_file
+
+    try:
+        subprocess.run(["charmcraft", "pack"], check=True, capture_output=True, text=True)  # nosec B603, B607
+    except subprocess.CalledProcessError as exc:
+        raise OSError(f"Error packing charm: {exc}; Stderr:\n{exc.stderr}") from None
+
+    app_name = metadata["name"]
+    charm_path = pathlib.Path(__file__).parent.parent.parent
+    charms = [p.absolute() for p in charm_path.glob(f"{app_name}_*.charm")]
+    assert charms, f"{app_name} .charm file not found"
+    assert len(charms) == 1, f"{app_name} has more than one .charm file, unsure which to use"
+    return str(charms[0])

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -236,7 +236,7 @@ def app_fixture(
         lambda status: jubilant.all_active(
             status, PROMETHEUS_APP, POSTGRESQL_APP, BLACKBOX_APP, SSC_APP, app_name
         ),
-        timeout=5000,
+        timeout=15*60,
     )
 
     # grafana_agent_app is

--- a/tests/integration/constants.py
+++ b/tests/integration/constants.py
@@ -45,6 +45,7 @@ GRAFANA_DASHBOARD_FILE = """{
 
 PROMETHEUS_RECEIVE_REMOTE_WRITE = "receive-remote-write"
 PROMETHEUS_APP = "prometheus-k8s"
+COS_CHANNEL = "1/stable"
 
 POSTGRESQL_APP = "postgresql-k8s"
 POSTGRESQL_APP_CHANNEL = "14/stable"

--- a/tests/integration/constants.py
+++ b/tests/integration/constants.py
@@ -43,8 +43,6 @@ GRAFANA_DASHBOARD_FILE = """{
   "panels": []
 }"""
 
-GRAFANA_DASHBOARD_FILES_DIRECTORY_DEVICES = pathlib.Path("./src/grafana_dashboards/devices/")
-
 PROMETHEUS_RECEIVE_REMOTE_WRITE = "receive-remote-write"
 PROMETHEUS_APP = "prometheus-k8s"
 

--- a/tests/integration/constants.py
+++ b/tests/integration/constants.py
@@ -2,7 +2,7 @@ import pathlib
 
 import yaml
 
-METADATA = yaml.safe_load(pathlib.Path("./charmcraft.yaml").read_text())
+METADATA = yaml.safe_load(pathlib.Path("./charmcraft.yaml").read_text(encoding="UTF-8"))
 RESOURCE_NAME = "cos-registration-server-image"
 APP_NAME = METADATA["name"]
 

--- a/tests/integration/constants.py
+++ b/tests/integration/constants.py
@@ -20,7 +20,6 @@ LOKI_ALERT_RULE_FILES_DIRECTORY_DEVICES = pathlib.Path("./src/loki_alert_rules/d
 PROMETHEUS_ALERT_RULE_FILES_DIRECTORY_DEVICES = pathlib.Path(
     "./src/prometheus_alert_rules/devices"
 )
-GRAFANA_DASHBOARD_FILES_DIRECTORY_DEVICES = pathlib.Path("./src/grafana_dashboards/devices")
 LOKI_ALERT_RULE_FILE = """groups:
         - name: example
           rules:
@@ -35,6 +34,8 @@ PROMETHEUS_ALERT_RULE_FILE = """groups:
             alert: my-alert
             expr: up == 0
             for: 5m"""
+
+GRAFANA_DASHBOARD_FILES_DIRECTORY_DEVICES = pathlib.Path("./src/grafana_dashboards/devices")
 GRAFANA_DASHBOARD_FILE = """{
   "title": "Example Dashboard",
   "schemaVersion": 36,

--- a/tests/integration/constants.py
+++ b/tests/integration/constants.py
@@ -1,0 +1,64 @@
+import pathlib
+
+import yaml
+
+METADATA = yaml.safe_load(pathlib.Path("./charmcraft.yaml").read_text())
+RESOURCE_NAME = "cos-registration-server-image"
+APP_NAME = METADATA["name"]
+
+APP_GRAFANA_DASHBOARD_DEVICES = "grafana-dashboard-devices"
+APP_LOGGING = "logging"
+APP_LOKI_ALERT_RULE_FILES_DEVICES = "logging-alerts-devices"
+APP_PROMETHEUS_ALERT_RULE_FILES_DEVICES = "send-remote-write-alerts-devices"
+APP_TRACING = "tracing"
+APP_PROBES = "probes"
+APP_PROBES_DEVICES = "probes-devices"
+APP_DATABASE = "database"
+APP_CERTIFICATES = "certificates"
+
+LOKI_ALERT_RULE_FILES_DIRECTORY_DEVICES = pathlib.Path("./src/loki_alert_rules/devices")
+PROMETHEUS_ALERT_RULE_FILES_DIRECTORY_DEVICES = pathlib.Path(
+    "./src/prometheus_alert_rules/devices"
+)
+GRAFANA_DASHBOARD_FILES_DIRECTORY_DEVICES = pathlib.Path("./src/grafana_dashboards/devices")
+LOKI_ALERT_RULE_FILE = """groups:
+        - name: example
+          rules:
+          - name: my-group
+            alert: my-alert
+            expr: up == 0
+            for: 5m"""
+PROMETHEUS_ALERT_RULE_FILE = """groups:
+        - name: example
+          rules:
+          - name: my-group
+            alert: my-alert
+            expr: up == 0
+            for: 5m"""
+GRAFANA_DASHBOARD_FILE = """{
+  "title": "Example Dashboard",
+  "schemaVersion": 36,
+  "version": 1,
+  "panels": []
+}"""
+
+GRAFANA_DASHBOARD_FILES_DIRECTORY_DEVICES = pathlib.Path("./src/grafana_dashboards/devices/")
+
+PROMETHEUS_RECEIVE_REMOTE_WRITE = "receive-remote-write"
+PROMETHEUS_APP = "prometheus-k8s"
+
+POSTGRESQL_APP = "postgresql-k8s"
+POSTGRESQL_APP_CHANNEL = "14/stable"
+POSTGRESQL_DATABASE = "database"
+
+GRAFANA_AGENT_APP = "grafana-agent-k8s"
+GRAFANA_AGENT_METRICS_ENDPOINT = "metrics-endpoint"
+GRAFANA_AGENT_GRAFANA_DASHBOARD = "grafana-dashboards-consumer"
+GRAFANA_AGENT_LOGGING_PROVIDER = "logging-provider"
+GRAFANA_AGENT_TRACING_ENDPOINT = "tracing-provider"
+
+BLACKBOX_APP = "blackbox-exporter-k8s"
+BLACKBOX_PROBES = "probes"
+
+SSC_APP = "self-signed-certificates"
+SSC_CERTIFICATES = "certificates"

--- a/tests/integration/juju.py
+++ b/tests/integration/juju.py
@@ -10,7 +10,7 @@ logger = logging.getLogger(__name__)
 
 def show_unit(juju: jubilant.Juju, unit: str) -> dict:
     """Return show-unit data for a unit."""
-    output = juju._cli("show-unit", unit, "--format", "json")
+    output = juju.cli("show-unit", unit, "--format", "json")
     if isinstance(output, (tuple, list)):
         output = output[0]
     data = json.loads(output)

--- a/tests/integration/juju.py
+++ b/tests/integration/juju.py
@@ -19,7 +19,7 @@ def show_unit(juju: jubilant.Juju, unit: str) -> dict:
     return data
 
 
-def relation_application_data(
+def get_relation_application_data(
     juju: jubilant.Juju,
     unit: str,
     endpoint: str,

--- a/tests/integration/juju.py
+++ b/tests/integration/juju.py
@@ -1,0 +1,48 @@
+"""Juju/Jubilant integration helpers."""
+
+import json
+import logging
+
+import jubilant
+
+logger = logging.getLogger(__name__)
+
+
+def show_unit(juju: jubilant.Juju, unit: str) -> dict:
+    """Return show-unit data for a unit."""
+    output = juju._cli("show-unit", unit, "--format", "json")
+    if isinstance(output, (tuple, list)):
+        output = output[0]
+    data = json.loads(output)
+    if isinstance(data, dict) and unit in data:
+        return data[unit]
+    return data
+
+
+def relation_application_data(
+    juju: jubilant.Juju,
+    unit: str,
+    endpoint: str,
+    related_unit: str,
+    related_endpoint: str,
+) -> list[dict]:
+    """Return relation application-data entries for a unit relation."""
+    unit_data = show_unit(juju, unit)
+    data_items: list[dict] = []
+    for rel in unit_data.get("relation-info", []):
+        if rel.get("endpoint") != endpoint:
+            continue
+        if rel.get("related-endpoint") != related_endpoint:
+            continue
+        related_units = rel.get("related-units", {})
+        if not isinstance(related_units, dict) or related_unit not in related_units:
+            continue
+        app_data = rel.get("application-data")
+        if isinstance(app_data, dict) and app_data:
+            data_items.append(app_data)
+        related_app = rel.get("related-application")
+        if isinstance(related_app, dict):
+            related_app_data = related_app.get("application-data")
+            if isinstance(related_app_data, dict) and related_app_data:
+                data_items.append(related_app_data)
+    return data_items

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -133,6 +133,7 @@ def test_blackbox_devices(juju):
 def test_integrate_self_signed_certificates(juju):
 
     data = get_relation_application_data(juju, APP_UNIT, APP_CERTIFICATES, SSC_UNIT, SSC_CERTIFICATES)
+    # expected to be empty since certificates are stored as secrets
     assert data == []
 
 

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -29,7 +29,7 @@ from tests.integration.constants import (
     SSC_APP,
     SSC_CERTIFICATES,
 )
-from tests.integration.juju import relation_application_data
+from tests.integration.juju import get_relation_application_data
 
 logger = logging.getLogger(__name__)
 
@@ -72,7 +72,7 @@ def test_deploy(cos_registration_server: str, juju):
 
 def test_alert_rules_devices(juju):
     """Test if devices alert rules are defined in relation."""
-    data = relation_application_data(
+    data = get_relation_application_data(
         juju,
         GRAFANA_AGENT_UNIT,
         GRAFANA_AGENT_LOGGING_PROVIDER,
@@ -84,7 +84,7 @@ def test_alert_rules_devices(juju):
 
 def test_grafana_dashboards_devices(juju):
     """Test if devices dashboards are defined in relation."""
-    data = relation_application_data(
+    data = get_relation_application_data(
         juju,
         GRAFANA_AGENT_UNIT,
         GRAFANA_AGENT_GRAFANA_DASHBOARD,
@@ -97,7 +97,7 @@ def test_grafana_dashboards_devices(juju):
 def test_prometheus_alert_rules_devices(juju):
     """Test if devices alert rules are defined in relation."""
     # migrate from prometheus to grafana_agent
-    data = relation_application_data(
+    data = get_relation_application_data(
         juju,
         PROMETHEUS_UNIT,
         PROMETHEUS_RECEIVE_REMOTE_WRITE,
@@ -110,7 +110,7 @@ def test_prometheus_alert_rules_devices(juju):
 
 def test_tracing(juju):
     """Test logging is defined in relation data bag."""
-    data = relation_application_data(
+    data = get_relation_application_data(
         juju, APP_UNIT, APP_TRACING, GRAFANA_AGENT_UNIT, GRAFANA_AGENT_TRACING_ENDPOINT
     )
     assert data
@@ -118,13 +118,13 @@ def test_tracing(juju):
 
 def test_blackbox(juju):
     """Test probes are defined in relation data bag."""
-    data = relation_application_data(juju, BLACKBOX_UNIT, BLACKBOX_PROBES, APP_UNIT, APP_PROBES)
+    data = get_relation_application_data(juju, BLACKBOX_UNIT, BLACKBOX_PROBES, APP_UNIT, APP_PROBES)
     assert "cos-registration-server-k8s/api/v1/health/" in data[0]["scrape_probes"]
 
 
 def test_blackbox_devices(juju):
     """Test devices probes are defined in relation data bag."""
-    data = relation_application_data(
+    data = get_relation_application_data(
         juju, BLACKBOX_UNIT, BLACKBOX_PROBES, APP_UNIT, APP_PROBES_DEVICES
     )
     assert data[0]["scrape_probes"]
@@ -132,12 +132,12 @@ def test_blackbox_devices(juju):
 
 def test_integrate_self_signed_certificates(juju):
 
-    data = relation_application_data(juju, APP_UNIT, APP_CERTIFICATES, SSC_UNIT, SSC_CERTIFICATES)
+    data = get_relation_application_data(juju, APP_UNIT, APP_CERTIFICATES, SSC_UNIT, SSC_CERTIFICATES)
     assert data == []
 
 
 def test_postgresql(juju):
-    data = relation_application_data(
+    data = get_relation_application_data(
         juju, APP_UNIT, APP_DATABASE, POSTGRESQL_UNIT, POSTGRESQL_DATABASE
     )
     database = data[0]["data"]

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -5,7 +5,6 @@
 import logging
 
 import jubilant
-import pytest
 
 from tests.integration.constants import (
     APP_CERTIFICATES,

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -66,7 +66,6 @@ SSC_UNIT = f"{SSC_APP}/0"
 POSTGRESQL_UNIT = f"{POSTGRESQL_APP}/0"
 
 
-@pytest.mark.abort_on_fail
 def test_deploy(cos_registration_server: str, juju):
     """Assert the deployment reaches active status."""
     wait_for_active_idle_without_error(juju)

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -96,7 +96,7 @@ def test_grafana_dashboards_devices(juju):
 
 def test_prometheus_alert_rules_devices(juju):
     """Test if devices alert rules are defined in relation."""
-    # migrate from prometheus to grafana_agent
+    # TODO: migrate from prometheus to grafana_agent
     data = get_relation_application_data(
         juju,
         PROMETHEUS_UNIT,

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -118,7 +118,9 @@ def test_tracing(juju):
 
 def test_blackbox(juju):
     """Test probes are defined in relation data bag."""
-    data = get_relation_application_data(juju, BLACKBOX_UNIT, BLACKBOX_PROBES, APP_UNIT, APP_PROBES)
+    data = get_relation_application_data(
+        juju, BLACKBOX_UNIT, BLACKBOX_PROBES, APP_UNIT, APP_PROBES
+    )
     assert "cos-registration-server-k8s/api/v1/health/" in data[0]["scrape_probes"]
 
 
@@ -132,7 +134,9 @@ def test_blackbox_devices(juju):
 
 def test_integrate_self_signed_certificates(juju):
 
-    data = get_relation_application_data(juju, APP_UNIT, APP_CERTIFICATES, SSC_UNIT, SSC_CERTIFICATES)
+    data = get_relation_application_data(
+        juju, APP_UNIT, APP_CERTIFICATES, SSC_UNIT, SSC_CERTIFICATES
+    )
     # expected to be empty since certificates are stored as secrets
     assert data == []
 

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -3,350 +3,146 @@
 # See LICENSE file for licensing details.
 
 import logging
-from pathlib import Path
 
+import jubilant
 import pytest
-import yaml
-from charmed_kubeflow_chisme.testing import (
+
+from tests.integration.constants import (
+    APP_CERTIFICATES,
+    APP_DATABASE,
+    APP_GRAFANA_DASHBOARD_DEVICES,
+    APP_LOKI_ALERT_RULE_FILES_DEVICES,
+    APP_NAME,
+    APP_PROBES,
+    APP_PROBES_DEVICES,
+    APP_PROMETHEUS_ALERT_RULE_FILES_DEVICES,
+    APP_TRACING,
+    BLACKBOX_APP,
+    BLACKBOX_PROBES,
     GRAFANA_AGENT_APP,
     GRAFANA_AGENT_GRAFANA_DASHBOARD,
     GRAFANA_AGENT_LOGGING_PROVIDER,
-    assert_grafana_dashboards,
-    assert_logging,
-    deploy_and_assert_grafana_agent,
-    get_grafana_dashboards,
+    GRAFANA_AGENT_TRACING_ENDPOINT,
+    POSTGRESQL_APP,
+    POSTGRESQL_DATABASE,
+    PROMETHEUS_APP,
+    PROMETHEUS_RECEIVE_REMOTE_WRITE,
+    SSC_APP,
+    SSC_CERTIFICATES,
 )
-from charmed_kubeflow_chisme.testing import (
-    get_alert_rules as get_alert_rule_from_files,
-)
-from charmed_kubeflow_chisme.testing.cos_integration import (
-    PROVIDES,
-    REQUIRES,
-    _get_app_relation_data,
-    _get_unit_relation_data,
-)
-from charmed_kubeflow_chisme.testing.cos_integration import (
-    _get_alert_rules as get_alert_rules_from_str,
-)
-from pytest_operator.plugin import OpsTest
+from tests.integration.juju import relation_application_data
 
 logger = logging.getLogger(__name__)
 
-METADATA = yaml.safe_load(Path("./charmcraft.yaml").read_text())
-RESOURCE_NAME = "cos-registration-server-image"
-RESOURCE_PATH = METADATA["resources"][RESOURCE_NAME]["upstream-source"]
-APP_NAME = METADATA["name"]
 
-APP_GRAFANA_DASHBOARD_DEVICES = "grafana-dashboard-devices"
-
-GRAFANA_AGENT_LOGGING_CONSUMER = "logging"
-APP_LOKI_ALERT_RULE_FILES_DEVICES = "logging-alerts-devices"
-APP_PROMETHEUS_ALERT_RULE_FILES_DEVICES = "send-remote-write-alerts-devices"
-
-LOKI_ALERT_RULE_FILES_DIRECTORY_DEVICES = Path("./src/loki_alert_rules/devices")
-PROMETHEUS_ALERT_RULE_FILES_DIRECTORY_DEVICES = Path("./src/prometheus_alert_rules/devices")
-LOKI_ALERT_RULE_FILE = """groups:
-        - name: example
-          rules:
-          - name: my-group
-            alert: my-alert
-            expr: up == 0
-            for: 5m"""
-PROMETHEUS_ALERT_RULE_FILE = """groups:
-        - name: example
-          rules:
-          - name: my-group
-            alert: my-alert
-            expr: up == 0
-            for: 5m"""
-
-PROMETHEUS_SEND_REMOTE_WRITE = "send-remote-write"
-PROMETHEUS_RECEIVE_REMOTE_WRITE = "receive-remote-write"
-PROMETHEUS_APP = "prometheus-k8s"
-
-POSTGRESQL_APP = "postgresql-k8s"
-POSTGRESQL_APP_CHANNEL = "14/stable"
-
-
-def create_alert_rule_files():
-    """Create alert rule files & directory if it does not exist."""
-    LOKI_ALERT_RULE_FILES_DIRECTORY_DEVICES.mkdir(parents=True, exist_ok=True)
-    PROMETHEUS_ALERT_RULE_FILES_DIRECTORY_DEVICES.mkdir(parents=True, exist_ok=True)
-    (LOKI_ALERT_RULE_FILES_DIRECTORY_DEVICES / "my_rule.rule").write_text(LOKI_ALERT_RULE_FILE)
-    (PROMETHEUS_ALERT_RULE_FILES_DIRECTORY_DEVICES / "my_rule.rule").write_text(
-        PROMETHEUS_ALERT_RULE_FILE
+def wait_for_active_idle_without_error(juju: jubilant.Juju, timeout: int = 60 * 45):
+    """Wait for the model to settle without errors."""
+    logger.info(f"waiting for the model ({juju.model}) to settle ...")
+    # grafana_agent_app stays in blocked state by design
+    juju.wait(
+        ready=lambda status: jubilant.all_active(
+            status, APP_NAME, POSTGRESQL_APP, PROMETHEUS_APP, BLACKBOX_APP, SSC_APP
+        ),
+        delay=10,
+        timeout=timeout,
+        error=jubilant.any_error,
     )
+    logger.info("waiting for agents idle ...")
+    juju.wait(
+        jubilant.all_agents_idle,
+        delay=10,
+        timeout=timeout,
+        error=lambda status: jubilant.any_error(
+            status, APP_NAME, POSTGRESQL_APP, PROMETHEUS_APP, BLACKBOX_APP, SSC_APP
+        ),
+    )
+
+
+APP_UNIT = f"{APP_NAME}/0"
+GRAFANA_AGENT_UNIT = f"{GRAFANA_AGENT_APP}/0"
+PROMETHEUS_UNIT = f"{PROMETHEUS_APP}/0"
+BLACKBOX_UNIT = f"{BLACKBOX_APP}/0"
+SSC_UNIT = f"{SSC_APP}/0"
+POSTGRESQL_UNIT = f"{POSTGRESQL_APP}/0"
 
 
 @pytest.mark.abort_on_fail
-async def test_build_and_deploy(ops_test: OpsTest):
-    """Build the charm-under-test and deploy it together with related charms.
+def test_deploy(cos_registration_server: str, juju):
+    """Assert the deployment reaches active status."""
+    wait_for_active_idle_without_error(juju)
 
-    Assert on the unit status before any relations/configurations take place.
-    """
-    create_alert_rule_files()
 
-    # Build and deploy charm from local source folder
-    charm = await ops_test.build_charm(".")
-    resources = {RESOURCE_NAME: RESOURCE_PATH}
-
-    # Deploy the charm
-    await ops_test.model.deploy(charm, resources=resources, application_name=APP_NAME)
-    # Deploy prometheus-k8s
-    # We must deploy prometheus since grafana-agent-k8s doesn't receive remote-write
-    await ops_test.model.deploy(PROMETHEUS_APP, channel="1/stable", trust=True)
-
-    # and wait for active/idle status
-    await ops_test.model.wait_for_idle(
-        apps=[PROMETHEUS_APP], status="active", raise_on_blocked=True, timeout=1000
-    )
-
-    # Deploying grafana-agent-k8s and add the logging relation
-    await deploy_and_assert_grafana_agent(
-        ops_test.model, APP_NAME, channel="1/stable", metrics=False, dashboard=True, logging=True
-    )
-    logger.info(
-        "Adding relation: %s:%s and %s:%s",
-        APP_NAME,
-        APP_GRAFANA_DASHBOARD_DEVICES,
-        GRAFANA_AGENT_APP,
-        GRAFANA_AGENT_GRAFANA_DASHBOARD,
-    )
-    await ops_test.model.integrate(
-        f"{APP_NAME}:{APP_GRAFANA_DASHBOARD_DEVICES}",
-        f"{GRAFANA_AGENT_APP}:{GRAFANA_AGENT_GRAFANA_DASHBOARD}",
-    )
-
-    logger.info(
-        "Adding relation: %s:%s and %s:%s",
-        APP_NAME,
-        APP_LOKI_ALERT_RULE_FILES_DEVICES,
-        GRAFANA_AGENT_APP,
+def test_alert_rules_devices(juju):
+    """Test if devices alert rules are defined in relation."""
+    data = relation_application_data(
+        juju,
+        GRAFANA_AGENT_UNIT,
         GRAFANA_AGENT_LOGGING_PROVIDER,
+        APP_UNIT,
+        APP_LOKI_ALERT_RULE_FILES_DEVICES,
     )
-    await ops_test.model.integrate(
-        f"{APP_NAME}:{APP_LOKI_ALERT_RULE_FILES_DEVICES}",
-        f"{GRAFANA_AGENT_APP}:{GRAFANA_AGENT_LOGGING_PROVIDER}",
-    )
+    assert "my-alert" in data[0]["alert_rules"]
 
-    logger.info(
-        "Adding relation: %s:%s and %s:%s",
-        APP_NAME,
-        APP_PROMETHEUS_ALERT_RULE_FILES_DEVICES,
-        PROMETHEUS_APP,
+
+def test_grafana_dashboards_devices(juju):
+    """Test if devices dashboards are defined in relation."""
+    data = relation_application_data(
+        juju,
+        GRAFANA_AGENT_UNIT,
+        GRAFANA_AGENT_GRAFANA_DASHBOARD,
+        APP_UNIT,
+        APP_GRAFANA_DASHBOARD_DEVICES,
+    )
+    assert "my-dashboard" in data[0]["dashboards"]
+
+
+def test_prometheus_alert_rules_devices(juju):
+    """Test if devices alert rules are defined in relation."""
+    # migrate from prometheus to grafana_agent
+    data = relation_application_data(
+        juju,
+        PROMETHEUS_UNIT,
         PROMETHEUS_RECEIVE_REMOTE_WRITE,
-    )
-    await ops_test.model.integrate(
-        f"{APP_NAME}:{APP_PROMETHEUS_ALERT_RULE_FILES_DEVICES}",
-        f"{PROMETHEUS_APP}:{PROMETHEUS_RECEIVE_REMOTE_WRITE}",
+        APP_UNIT,
+        APP_PROMETHEUS_ALERT_RULE_FILES_DEVICES,
     )
 
-    logger.info(
-        "Adding relation: %s:%s and %s:%s",
-        APP_NAME,
-        "tracing",
-        GRAFANA_AGENT_APP,
-        "tracing-provider",
-    )
-    await ops_test.model.integrate(
-        f"{APP_NAME}:tracing",
-        f"{GRAFANA_AGENT_APP}:tracing-provider",
-    )
-
-    await ops_test.model.deploy(POSTGRESQL_APP, channel=POSTGRESQL_APP_CHANNEL, trust=True)
-    logger.info(
-        "Adding relation: %s:%s and %s:%s",
-        APP_NAME,
-        "database",
-        POSTGRESQL_APP,
-        "database",
-    )
-    await ops_test.model.integrate(
-        f"{APP_NAME}:database",
-        f"{POSTGRESQL_APP}:database",
-    )
-
-    await ops_test.model.wait_for_idle(apps=[APP_NAME], status="active", timeout=1000)
+    assert "my-alert" in data[0]["alert_rules"]
 
 
-async def test_status(ops_test):
-    """Assert on the unit status."""
-    assert ops_test.model.applications[APP_NAME].units[0].workload_status == "active"
-
-
-async def test_logging(ops_test: OpsTest):
+def test_tracing(juju):
     """Test logging is defined in relation data bag."""
-    app = ops_test.model.applications[APP_NAME]
-    await assert_logging(app)
-
-
-async def test_grafana_dashboards(ops_test: OpsTest):
-    """Test Grafana dashboards are defined in relation data bag."""
-    app = ops_test.model.applications[APP_NAME]
-    dashboards = get_grafana_dashboards()
-    logger.info("found dashboards: %s", dashboards)
-    await assert_grafana_dashboards(app, dashboards)
-
-
-async def test_grafana_dashboards_devices(ops_test: OpsTest, mocker):
-    """Test Grafana dashboards are defined in relation data bag."""
-    app = ops_test.model.applications[APP_NAME]
-    # @todo get dashboard 'from db'
-    dashboards = set()
-    logger.info("found dashboards: %s", dashboards)
-    mocker.patch(
-        "charmed_kubeflow_chisme.testing.cos_integration.APP_GRAFANA_DASHBOARD",
-        "grafana-dashboard-devices",
+    data = relation_application_data(
+        juju, APP_UNIT, APP_TRACING, GRAFANA_AGENT_UNIT, GRAFANA_AGENT_TRACING_ENDPOINT
     )
-    await assert_grafana_dashboards(app, dashboards)
+    assert data
 
 
-async def test_loki_alert_rules_devices(ops_test: OpsTest):
-    """Test Loki alert rules for devices are defined in relation data bag."""
-    async with ops_test.fast_forward():
-        await ops_test.model.wait_for_idle(apps=[APP_NAME], status="active", timeout=120)
-    app = ops_test.model.applications[APP_NAME]
-    # Get the set of rules that should have been pre-loaded
-    alert_rules = get_alert_rule_from_files(LOKI_ALERT_RULE_FILES_DIRECTORY_DEVICES)
-    logger.info("found alert rules: %s", alert_rules)
-    # Get the dict of rules that has been received
-    relation_data = await _get_app_relation_data(
-        app, APP_LOKI_ALERT_RULE_FILES_DEVICES, side=REQUIRES
-    )
-    assert (
-        "alert_rules" in relation_data
-    ), f"{APP_LOKI_ALERT_RULE_FILES_DEVICES} relation is missing 'alert_rules'"  # fmt: skip
-
-    relation_alert_rules = get_alert_rules_from_str(relation_data["alert_rules"])
-    assert relation_alert_rules == alert_rules
-
-
-async def test_prometheus_alert_rules_devices(ops_test: OpsTest):
-    """Test Loki alert rules for devices are defined in relation data bag."""
-    async with ops_test.fast_forward():
-        await ops_test.model.wait_for_idle(apps=[APP_NAME], status="active", timeout=120)
-    app = ops_test.model.applications[APP_NAME]
-    alert_rules = get_alert_rule_from_files(PROMETHEUS_ALERT_RULE_FILES_DIRECTORY_DEVICES)
-    logger.info("found alert rules: %s", alert_rules)
-    relation_data = await _get_app_relation_data(
-        app, APP_PROMETHEUS_ALERT_RULE_FILES_DEVICES, side=REQUIRES
-    )
-
-    relation_alert_rules = get_alert_rules_from_str(relation_data["alert_rules"])
-    assert relation_alert_rules == alert_rules
-
-
-async def test_tracing(ops_test: OpsTest):
-    """Test logging is defined in relation data bag."""
-    app = ops_test.model.applications[APP_NAME]
-
-    unit_relation_data = await _get_unit_relation_data(app, "tracing", side=PROVIDES)
-
-    assert unit_relation_data
-
-
-async def test_integrate_blackbox(ops_test: OpsTest):
-    # @todo: upgrade to stable when blackbox charm with probes relation
-    # is promoted from edge.
-    await ops_test.model.deploy("blackbox-exporter-k8s", "blackbox", channel="1/edge", trust=True)
-
-    logger.info(
-        "Adding relation: %s:%s",
-        APP_NAME,
-        "probes",
-    )
-
-    await ops_test.model.integrate(
-        f"{APP_NAME}:probes",
-        "blackbox:probes",
-    )
-
-    await ops_test.model.wait_for_idle(
-        apps=[
-            f"{APP_NAME}",
-            "blackbox",
-        ],
-        status="active",
-    )
-
-
-async def test_blackbox(ops_test: OpsTest):
+def test_blackbox(juju):
     """Test probes are defined in relation data bag."""
-    app = ops_test.model.applications[APP_NAME]
-
-    relation_data = await _get_app_relation_data(app, "probes", side=PROVIDES)
-
-    assert relation_data.get("scrape_metadata")
-    assert relation_data.get("scrape_probes")
+    data = relation_application_data(juju, BLACKBOX_UNIT, BLACKBOX_PROBES, APP_UNIT, APP_PROBES)
+    assert "cos-registration-server-k8s/api/v1/health/" in data[0]["scrape_probes"]
 
 
-async def test_integrate_blackbox_devices(ops_test: OpsTest):
-    logger.info(
-        "Adding relation: %s:%s",
-        APP_NAME,
-        "probes-devices",
+def test_blackbox_devices(juju):
+    """Test devices probes are defined in relation data bag."""
+    data = relation_application_data(
+        juju, BLACKBOX_UNIT, BLACKBOX_PROBES, APP_UNIT, APP_PROBES_DEVICES
     )
+    assert data[0]["scrape_probes"]
 
-    await ops_test.model.integrate(
-        f"{APP_NAME}:probes-devices",
-        "blackbox:probes",
+
+def test_integrate_self_signed_certificates(juju):
+
+    data = relation_application_data(juju, APP_UNIT, APP_CERTIFICATES, SSC_UNIT, SSC_CERTIFICATES)
+    assert data == []
+
+
+def test_postgresql(juju):
+    data = relation_application_data(
+        juju, APP_UNIT, APP_DATABASE, POSTGRESQL_UNIT, POSTGRESQL_DATABASE
     )
-
-    await ops_test.model.wait_for_idle(
-        apps=[
-            f"{APP_NAME}",
-            "blackbox",
-        ],
-        status="active",
-    )
-
-
-async def test_blackbox_devices(ops_test: OpsTest):
-    """Test probes devices are defined in relation data bag."""
-    app = ops_test.model.applications[APP_NAME]
-
-    relation_data = await _get_app_relation_data(app, "probes-devices", side=PROVIDES)
-
-    # no devices registered when testing
-    assert relation_data.get("scrape_probes")
-
-
-async def test_integrate_self_signed_certificates(ops_test: OpsTest):
-    await ops_test.model.deploy(
-        "self-signed-certificates", "self-signed-certificates", channel="1/stable", trust=True
-    )
-
-    logger.info(
-        "Adding relation: %s:%s",
-        APP_NAME,
-        "certificates",
-    )
-
-    await ops_test.model.integrate(
-        f"{APP_NAME}:certificates",
-        "self-signed-certificates:certificates",
-    )
-
-    await ops_test.model.wait_for_idle(
-        apps=[
-            f"{APP_NAME}",
-            "self-signed-certificates",
-        ],
-        status="active",
-    )
-
-
-async def test_postgresql(ops_test: OpsTest):
-    """Test that the postgresql URL is integrated."""
-    app = ops_test.model.applications[APP_NAME]
-    database_app = ops_test.model.applications[POSTGRESQL_APP]
-
-    relation_data = await _get_app_relation_data(app, "database", side=REQUIRES)
-    database_relation_data = await _get_app_relation_data(database_app, "database", side=PROVIDES)
-
-    # Ensure PostgreSQL relation data contains required fields
-    assert relation_data.get("database")
-    assert database_relation_data.get("endpoints")
-    requested_secrets = relation_data.get("requested-secrets")
-    assert "username" in requested_secrets
-    assert "password" in requested_secrets
+    database = data[0]["data"]
+    assert "requested-secrets" in database
+    assert "username" in database
+    assert "password" in database

--- a/tox.ini
+++ b/tox.ini
@@ -102,7 +102,7 @@ deps =
     pytest-mock
     pytest-operator
 commands =
-    pytest -vv --tb native --log-cli-level=INFO --color=yes -s {posargs} {toxinidir}/tests/integration
+    python -m pytest -vv --tb native --log-cli-level=INFO --color=yes -s {posargs} {toxinidir}/tests/integration
 
 [testenv:terraform-format]
 description = Format terraform files

--- a/tox.ini
+++ b/tox.ini
@@ -93,14 +93,10 @@ description = Run scenario tests
 [testenv:integration]
 description = Run integration tests
 deps =
-    aiohttp
-    asyncstdlib
-    charmed-kubeflow-chisme==0.4.3
-    # Libjuju needs to track the juju version
-    juju ~= 3.5.2.1
     pytest
     pytest-mock
     pytest-operator
+    jubilant
 commands =
     python -m pytest -vv --tb native --log-cli-level=INFO --color=yes -s {posargs} {toxinidir}/tests/integration
 

--- a/tox.ini
+++ b/tox.ini
@@ -100,6 +100,7 @@ deps =
     pytest
     pytest-mock
     jubilant
+    -r{toxinidir}/requirements.txt
 commands =
     python -m pytest -vv --tb native --log-cli-level=INFO --color=yes -s {posargs} {toxinidir}/tests/integration
 

--- a/tox.ini
+++ b/tox.ini
@@ -29,23 +29,20 @@ passenv =
 [testenv:fmt]
 description = Apply coding style standards to code
 deps =
-    black
     ruff
 commands =
     ruff check --fix {[vars]all_path}
-    black {[vars]all_path}
+    ruff format {[vars]all_path}
 
 [testenv:lint]
 description = Check code against coding style standards
 deps =
-    black
     ruff
     codespell
 commands =
     codespell . --skip .git --skip .tox --skip build --skip lib --skip venv --skip .mypy_cache
     ruff check {[vars]all_path}
     ruff format --check --diff {[vars]all_path}
-    black --check --diff {[vars]all_path}
 
 [testenv:reqs]
 description = Check for missing or unused requirements

--- a/tox.ini
+++ b/tox.ini
@@ -25,6 +25,10 @@ passenv =
   HTTP_PROXY
   HTTPS_PROXY
   NO_PROXY
+  JUJU_USE_EXISTING
+  JUJU_MODEL
+  JUJU_KEEP_MODELS
+  CHARM_FILE
 
 [testenv:fmt]
 description = Apply coding style standards to code
@@ -95,7 +99,6 @@ description = Run integration tests
 deps =
     pytest
     pytest-mock
-    pytest-operator
     jubilant
 commands =
     python -m pytest -vv --tb native --log-cli-level=INFO --color=yes -s {posargs} {toxinidir}/tests/integration


### PR DESCRIPTION
Replace ops testing with pure jubilant for the integration tests.

The tests were just migrated. No additional tests were added.