### PR TITLE
[hermes-agent] fix: add explicit release workflow permissions

### DIFF
--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -56,6 +56,11 @@ jobs:
 
   pull-request:
     name: PR
+    permissions:
+      actions: read
+      contents: read
+      issues: write
+      security-events: write
     uses: canonical/observability/.github/workflows/charm-pull-request.yaml@v0
     secrets: inherit
     with:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -12,8 +12,10 @@ on:
       - track/**
 
 permissions:
+  actions: read
   contents: write
-  pull-requests: read
+  issues: write
+  security-events: write
 
 jobs:
   release:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -11,14 +11,13 @@ on:
       - main
       - track/**
 
-permissions:
-  actions: read
-  contents: write
-  issues: write
-  security-events: write
-
 jobs:
   release:
+    permissions:
+      actions: read
+      contents: write
+      issues: write
+      security-events: write
     uses: canonical/observability/.github/workflows/charm-release.yaml@v0
     with:
       juju-channel: "3.6/stable"

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -11,6 +11,10 @@ on:
       - main
       - track/**
 
+permissions:
+  contents: write
+  pull-requests: read
+
 jobs:
   release:
     uses: canonical/observability/.github/workflows/charm-release.yaml@v0


### PR DESCRIPTION
[hermes-agent]

## Summary
- Adds explicit workflow-level token permissions to the release workflow caller.
- Fixes startup failure for the reusable release workflow under restricted default GITHUB_TOKEN permissions.

## Root cause
The release workflow (`.github/workflows/release.yaml`) called a reusable workflow but did not declare caller-level permissions. With restricted defaults, this can fail at workflow startup before jobs are created.

## Test Plan
- Re-run `Release Charm to Edge and Publish Libraries` after merge.
- Confirm workflow starts and creates jobs normally.
